### PR TITLE
Add Gen VII (Sun/Moon) Pokémon and update stories

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ render() {
 ## Props
 
 - `name` (string) - pokemon name - *required*
-- `gen` (string) - generation ['xy', 'black-white', 'diamond-pearl', 'emerald', 'silver', 'green']
+- `gen` (string) - generation ['sun-moon', 'xy', 'black-white', 'diamond-pearl', 'emerald', 'silver', 'green'] - *defaults to `xy`*
 - `label` (bool) - show pokemon name
 
 ## Architecture

--- a/src/Main.js
+++ b/src/Main.js
@@ -2,10 +2,17 @@ import React, { PropTypes } from 'react';
 
 const Pokemon = ({ name, gen, label }) => (
     <div className="pokemon">
-        <img
-            src={`http://www.pokestadium.com/sprites/${gen}/${name}.${(gen === 'xy') ? 'gif' : 'png'}`}
-            alt={name}
-        />
+        {gen === 'sun-moon' ? (
+            <img
+                src={`https://www.pkparaiso.com/imagenes/sol-luna/sprites/animados/${name}.gif`}
+                alt={name}
+            />
+        ) : (
+            <img
+                src={`http://www.pokestadium.com/sprites/${gen}/${name}.${(gen === 'xy') ? 'gif' : 'png'}`}
+                alt={name}
+            />
+        )}
         {label &&
             <p>{name}</p>
         }

--- a/stories/Main.js
+++ b/stories/Main.js
@@ -27,6 +27,12 @@ storiesOf('Pokemon', module)
     .add('with all pikachu gen', () => (
         <div>
             <Pokemon name="pikachu" />
+            <Pokemon name="pikachu-kantocap" gen="sun-moon" />
+            <Pokemon name="pikachu-hoenncap" gen="sun-moon" />
+            <Pokemon name="pikachu-sinnohcap" gen="sun-moon" />
+            <Pokemon name="pikachu-unovacap" gen="sun-moon" />
+            <Pokemon name="pikachu-kaloscap" gen="sun-moon" />
+            <Pokemon name="pikachu-alolacap" gen="sun-moon" />
             <Pokemon name="pikachu" gen="black-white" />
             <Pokemon name="pikachu" gen="diamond-pearl" />
             <Pokemon name="pikachu" gen="emerald" />
@@ -37,6 +43,8 @@ storiesOf('Pokemon', module)
     .add('with all charizard gen', () => (
         <div>
             <Pokemon name="charizard" />
+            <Pokemon name="charizard-megax" />
+            <Pokemon name="charizard-megay" />
             <Pokemon name="charizard" gen="black-white" />
             <Pokemon name="charizard" gen="diamond-pearl" />
             <Pokemon name="charizard" gen="emerald" />
@@ -52,4 +60,68 @@ storiesOf('Pokemon', module)
             <Pokemon name="squirtle" />
         </div>
     ))
-
+    .add('with all starters', () => (
+        <div>
+            <Pokemon name="bulbasaur" />
+            <Pokemon name="charmander" />
+            <Pokemon name="squirtle" />
+            <Pokemon name="chikorita" />
+            <Pokemon name="cyndaquil" />
+            <Pokemon name="totodile" />
+            <Pokemon name="treecko" />
+            <Pokemon name="torchic" />
+            <Pokemon name="mudkip" />
+            <Pokemon name="turtwig" />
+            <Pokemon name="chimchar" />
+            <Pokemon name="piplup" />
+            <Pokemon name="snivy" />
+            <Pokemon name="tepig" />
+            <Pokemon name="oshawott" />
+            <Pokemon name="chespin" />
+            <Pokemon name="fennekin" />
+            <Pokemon name="froakie" />
+            <Pokemon name="rowlet" gen="sun-moon" />
+            <Pokemon name="litten" gen="sun-moon" />
+            <Pokemon name="popplio" gen="sun-moon" />
+        </div>
+    ))
+    .add('pikachu family', () => (
+        <div>
+            <Pokemon name="pichu" />
+            <Pokemon name="pikachu" />
+            <Pokemon name="raichu" />
+            <Pokemon name="raichu-alola" gen="sun-moon" />
+            <Pokemon name="plusle" />
+            <Pokemon name="minun" />
+            <Pokemon name="pachirisu" />
+            <Pokemon name="emolga" />
+            <Pokemon name="dedenne" />
+            <Pokemon name="togedemaru" gen="sun-moon" />
+        </div>
+    ))
+    .add('mega evolutions', () => (
+        <div>
+            <Pokemon name="venusaur-mega" />
+            <Pokemon name="charizard-megax" />
+            <Pokemon name="charizard-megay" />
+            <Pokemon name="blastoise-mega" />
+            <Pokemon name="gengar-mega" />
+            <Pokemon name="kangaskhan-mega" />
+            <Pokemon name="mewtwo-megax" />
+            <Pokemon name="mewtwo-megay" />
+            <Pokemon name="latias-mega" />
+        </div>
+    ))
+    .add('alola forms', () => (
+        <div>
+            <Pokemon name="raticate-alola" gen="sun-moon" />
+            <Pokemon name="raichu-alola" gen="sun-moon" />
+            <Pokemon name="sandslash-alola" gen="sun-moon" />
+            <Pokemon name="ninetales-alola" gen="sun-moon" />
+            <Pokemon name="dugtrio-alola" gen="sun-moon" />
+            <Pokemon name="meowth-alola" gen="sun-moon" />
+            <Pokemon name="muk-alola" gen="sun-moon" />
+            <Pokemon name="marowak-alola" gen="sun-moon" />
+            <Pokemon name="exeggutor-alola" gen="sun-moon" />
+        </div>
+    ))

--- a/tests/specs/Main.spec.js
+++ b/tests/specs/Main.spec.js
@@ -35,9 +35,19 @@ describe('Pokemon', () => {
         expect(wrapper.find('img').props().src.includes('.gif')).to.equal(true);
     });
 
-    it('should get png image when different than xy gen', () => {
+    it('should get gif image when sun-moon gen', () => {
+        const wrapper = shallow(<Pokemon name="rowlet" gen="sun-moon" />);
+        expect(wrapper.find('img').props().src.includes('.gif')).to.equal(true);
+    });
+
+    it('should get png image when gen is different than xy or sun-moon', () => {
         const wrapper = shallow(<Pokemon name="pikachu" gen="black-white" />);
         expect(wrapper.find('img').props().src.includes('.png')).to.equal(true);
+    });
+
+    it('should get image from sun-moon gen if gen passed', () => {
+        const wrapper = shallow(<Pokemon name="litten" gen="sun-moon" />);
+        expect(wrapper.find('img').props().src.includes('/sol-luna/')).to.equal(true);
     });
 
     it('should get image from black-white gen if gen passed', () => {


### PR DESCRIPTION
This PR adds the ability to show Pokémon from Generation VII (Sun/Moon). Unfortunately pokestadium.com doesn't have sprites for Gen VII, so I had to use pkparaiso.com in this case.

Also added stories to show mega evolutions and Alola forms.